### PR TITLE
Change the `compressedDisassembled` encoding to save size

### DIFF
--- a/contract-deconstruct/src/agent.ts
+++ b/contract-deconstruct/src/agent.ts
@@ -131,7 +131,7 @@ const runTx = async (txEvent: TransactionEvent) => {
     if(receipt.status && contractAddressFromReceipt) {
       const result = await handleTransactionInternal(contractAddressFromReceipt)
       var compressedDisassembled: any = await asyncDeflate(JSON.stringify(result.disassembled));
-      compressedDisassembled = compressedDisassembled.toString('base64');
+      compressedDisassembled = compressedDisassembled.toString('utf-8');
 
       // var compressedAnalysis: any = await asyncDeflate(JSON.stringify(result.analysis))
       // compressedAnalysis = compressedAnalysis.toString('base64');


### PR DESCRIPTION
Changing the `compressedDisassembled` encoding from `base64` to `utf-8` gets rid of the base64 overhead to save size in the metadata of the finding.