### PR TITLE
Add more interfaces 

### DIFF
--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -32,6 +32,7 @@ import {
   isItGovernor,
   isItTimelockController,
   isItVotes,
+  isItVestingWallet,
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -235,6 +236,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'Votes', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItVestingWallet(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'VestingWallet', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -34,6 +34,7 @@ import {
   isItVotes,
   isItVestingWallet,
   isItPaymentSplitter,
+  isItERC165,
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -261,6 +262,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'PaymentSplitter', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItERC165(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'ERC165', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -29,6 +29,7 @@ import {
   isItInitializable, 
   isItPausable,
   isItPullPayment,
+  isItGovernor,
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -196,6 +197,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'PullPayment', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItGovernor(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'Governor', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -30,6 +30,7 @@ import {
   isItPausable,
   isItPullPayment,
   isItGovernor,
+  isItTimelockController,
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -209,6 +210,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'Governor', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItTimelockController(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'TimelockController', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -33,6 +33,7 @@ import {
   isItTimelockController,
   isItVotes,
   isItVestingWallet,
+  isItPaymentSplitter,
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -248,6 +249,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'VestingWallet', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItPaymentSplitter(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'PaymentSplitter', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -18,6 +18,7 @@ import {
   isItOwnable,
   isItERC20,
   isItERC721,
+  isItERC1155,
   isItAccessControl,
   isItProxy,
   isItUUPS,
@@ -60,6 +61,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'ERC721', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItERC1155(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'ERC1155', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -19,6 +19,7 @@ import {
   isItERC20,
   isItERC721,
   isItERC1155,
+  isItERC777,
   isItAccessControl,
   isItProxy,
   isItUUPS,
@@ -73,6 +74,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'ERC1155', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItERC777(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'ERC777', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -26,7 +26,8 @@ import {
   isItERC1967,
   isItProxyAdmin,
   isItTransparentUpgradeableProxyPattern,
-  isItInitializable
+  isItInitializable, 
+  isItPausable
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -173,6 +174,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
       status: result, 
       fmatches: functionmatches, 
       ematches: null,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItPausable(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'Pausable', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
       extras: {}
     }
   );

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -27,7 +27,8 @@ import {
   isItProxyAdmin,
   isItTransparentUpgradeableProxyPattern,
   isItInitializable, 
-  isItPausable
+  isItPausable,
+  isItPullPayment,
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -183,6 +184,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'Pausable', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItPullPayment(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'PullPayment', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/agent.ts
+++ b/interface-detector/src/agent.ts
@@ -31,6 +31,7 @@ import {
   isItPullPayment,
   isItGovernor,
   isItTimelockController,
+  isItVotes,
 } from './inspectors'
 
 const analyzeInterface = (events: any[], functions: any[]) => {
@@ -222,6 +223,18 @@ const analyzeInterface = (events: any[], functions: any[]) => {
   observationResults.push(
     {
       type: 'TimelockController', 
+      status: result, 
+      fmatches: functionmatches, 
+      ematches: eventmatches,
+      extras: {}
+    }
+  );
+
+  var {result, functionmatches, eventmatches} = isItVotes(parsedData.eventsGroupedByHex, parsedData.functionsGroupedByHex)
+
+  observationResults.push(
+    {
+      type: 'Votes', 
       status: result, 
       fmatches: functionmatches, 
       ematches: eventmatches,

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -574,3 +574,37 @@ export function isItTimelockController(events: any[], functions: any[]) {
         eventmatches: null
     }
 }
+
+export function isItVotes(events: any[], functions: any[]) {
+
+    var functionsInInterface: any[] = [
+        'getVotes(address)',
+        'getPastVotes(address,uint256)',
+        'getPastTotalSupply(uint256)',
+        'delegates(address)',
+        'delegate(address)',
+        'delegateBySig(address,uint256,uint256,uint8,bytes32,bytes32)',
+    ];
+
+    var eventsInInterface = [
+        'DelegateChanged(address,address,address)',
+        'DelegateVotesChanged(address,uint256,uint256)',
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -423,7 +423,6 @@ export function isItInitializable(functions: any[]) {
 /****************** SECURITY *******************************/
 
 export function isItPausable(events: any[], functions: any[]) {
-    // ProxyAdmin must be Ownable -> should it ?
 
     var functionsInInterface: any[] = [
         "paused()",
@@ -433,6 +432,33 @@ export function isItPausable(events: any[], functions: any[]) {
         'Paused(address)',
         'Unpaused(address)'
     ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}
+
+export function isItPullPayment(events: any[], functions: any[]) {
+
+    var functionsInInterface: any[] = [
+        'withdrawPayments(address)',
+        'payments(address)'
+    ];
+
+    var eventsInInterface = ['']
 
     var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
         events, 

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -458,7 +458,60 @@ export function isItPullPayment(events: any[], functions: any[]) {
         'payments(address)'
     ];
 
-    var eventsInInterface = ['']
+    var eventsInInterface: any[] = []
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}
+
+/****************** GOVERNANCE *******************************/
+
+export function isItGovernor(events: any[], functions: any[]) {
+
+    var functionsInInterface: any[] = [
+        'name()',
+        'version()',
+        'COUNTING_MODE()',
+        'hashProposal(address[],int256[],bytes[],bytes32)',
+        'state(uint256)',
+        'proposalSnapshot(uint256)',
+        'proposalDeadline(uint256)',
+        'votingDelay()',
+        'votingPeriod()',
+        'quorum(uint256)',
+        'getVotes(address,uint256)',
+        'getVotesWithParams(address,uint256,bytes)',
+        'hasVoted(uint256,address)',
+        'propose(address[],uint256[],bytes[],string)',
+        'execute(address[],uint256[],bytes[],bytes32)',
+        'castVote(uint256,uint8)',
+        'castVoteWithReason(uint256,uint8,string)',
+        'castVoteWithReasonAndParams(uint256,uint8,string,bytes)',
+        'castVoteBySig(uint256,uint8,uint8,bytes32,bytes32)',
+        'castVoteWithReasonAndParamsBySig(uint256,uint8,string,bytes,uint8,bytes32,bytes32)'
+    ];
+
+    var eventsInInterface = [
+        'ProposalCreated(uint256,address,address[],uint256[],string[],bytes[],uint256,uint256,string)',
+        'ProposalCanceled(uint256)',
+        'ProposalExecuted(uint256)',
+        'VoteCast(address,uint256,uint8,uint256,string)',
+        'VoteCastWithParams(address,uint256,uint8,uint256,string,bytes)'
+    ]
 
     var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
         events, 

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -168,6 +168,49 @@ export function isItERC1155(events: any[], functions: any[]) {
     }
 }
 
+export function isItERC777(events: any[], functions: any[]) {
+    var functionsInInterface = [
+        'name()',
+        'symbol()',
+        'granularity()',
+        'totalSupply()',
+        'balanceOf(address)',
+        'send(address,uint256,bytes)',
+        'burn(uint256,bytes)',
+        'isOperatorFor(address,address)',
+        'authorizeOperator(address)',
+        'revokeOperator(address)',
+        'defaultOperators()',
+        'operatorSend(address,address,uint256,bytes,bytes)',
+        'operatorBurn(address,uint256,bytes,bytes)',
+    ];
+
+    var eventsInInterface = [
+        'Minted(address,address,uint256,bytes,bytes)',
+        'Burned(address,address,uint256,bytes,bytes)',
+        'AuthorizedOperator(address,address)',
+        'RevokedOperator(address,address)',
+        'Sent(address,address,address,uint256,bytes,bytes)'
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}
+
 export function isItAccessControl(events: any[], functions: any[]) {
     var functionsInInterface = [
         'hasRole(bytes32,address)',

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -530,3 +530,47 @@ export function isItGovernor(events: any[], functions: any[]) {
         eventmatches: null
     }
 }
+
+export function isItTimelockController(events: any[], functions: any[]) {
+
+    var functionsInInterface: any[] = [
+        'isOperation(bytes32)',
+        'isOperationPending(bytes32)',
+        'isOperationReady(bytes32)',
+        'isOperationDone(bytes32)',
+        'getTimestamp(bytes32)',
+        'getMinDelay()',
+        'hashOperation(address,uint256,bytes,bytes32,bytes32)',
+        'hashOperationBatch(address[],uint256[],bytes[],bytes32,bytes32)',
+        'schedule(address,uint256,bytes,bytes32,bytes32,uint256)',
+        'scheduleBatch(address[],uint256[],bytes[],bytes32,bytes32,uint256)',
+        'cancel(bytes32)',
+        'execute(address,uint256,bytes,bytes32,bytes32)',
+        'executeBatch(address[],uint256[],bytes[],bytes32,bytes32)',
+        'updateDelay(uint256)'
+    ];
+
+    var eventsInInterface = [
+        'CallScheduled(bytes32,uint256,address,uint256,bytes,bytes32,uint256)',
+        'CallExecuted(bytes32,uint256,address,uint256,bytes)',
+        'Cancelled(bytes32)',
+        'MinDelayChange(uint256,uint256)'
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -61,6 +61,8 @@ export function isItOwnable(events: any[], functions: any[]) {
     }
 }
 
+/****************** TOKENS *******************************/
+
 export function isItERC20(events: any[], functions: any[]) {
     var functionsInInterface = [
         'totalSupply()',
@@ -411,6 +413,38 @@ export function isItInitializable(functions: any[]) {
         result: true, 
         functionmatches: initializerFunctions,
         eventmatches: null
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}
+
+/****************** SECURITY *******************************/
+
+export function isItPausable(events: any[], functions: any[]) {
+    // ProxyAdmin must be Ownable -> should it ?
+
+    var functionsInInterface: any[] = [
+        "paused()",
+    ];
+
+    var eventsInInterface = [
+        'Paused(address)',
+        'Unpaused(address)'
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
     }; else return {
         result: false, 
         functionmatches: null, 

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -133,6 +133,41 @@ export function isItERC721(events: any[], functions: any[]) {
     }
 }
 
+export function isItERC1155(events: any[], functions: any[]) {
+    var functionsInInterface = [
+        'balanceOf(address,uint256)',
+        'balanceOfBatch(address[],uint256[])',
+        'setApprovalForAll(address,bool)',
+        'isApprovedForAll(address,address)',
+        'safeTransferFrom(address,address,uint256,uint256,bytes)',
+        'safeBatchTransferFrom(address,address,uint256[],uint256[],bytes)',
+    ];
+
+    var eventsInInterface = [
+        'TransferSingle(address,address,address,uint256,uint256)',
+        'TransferBatch(address,address,address,uint256[],uint256[])',
+        'ApprovalForAll(address,address,bool)',
+        'URI(string,uint256)',
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}
+
 export function isItAccessControl(events: any[], functions: any[]) {
     var functionsInInterface = [
         'hasRole(bytes32,address)',

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -107,8 +107,7 @@ export function isItERC721(events: any[], functions: any[]) {
         'isApprovedForAll(address,address)',
         'transferFrom(address,address,uint256)',
         'safeTransferFrom(address,address,uint256)',
-        'safeTransferFrom(address,address,uint256,bytes)',
-        'supportsInterface(bytes4)'
+        'safeTransferFrom(address,address,uint256,bytes)'
     ];
 
     var eventsInInterface = [
@@ -671,6 +670,35 @@ export function isItPaymentSplitter(events: any[], functions: any[]) {
         'PaymentReleased(address,uint256)',
         'ERC20PaymentReleased(address,address,uint256)',
         'PaymentReceived(address,uint256)'
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}
+
+/****************** UTILS *******************************/
+
+export function isItERC165(events: any[], functions: any[]) {
+
+    var functionsInInterface = [
+        'supportsInterface(bytes4)'
+    ];
+
+    var eventsInInterface: any[] = [
     ]
 
     var {isItInterface, functionMatchesResults, eventMatchesResults} = match(

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -649,3 +649,44 @@ export function isItVestingWallet(events: any[], functions: any[]) {
         eventmatches: null
     }
 }
+
+export function isItPaymentSplitter(events: any[], functions: any[]) {
+
+    var functionsInInterface: any[] = [
+        'totalShares()',
+        'totalReleased()',
+        'totalReleased(address)',
+        'shares(address)',
+        'released(address)',
+        'released(address,address)',
+        'payee(uint256)',
+        'releasable(address)',
+        'releasable(address,address)',
+        'release(address)',
+        'release(address,address)'
+    ];
+
+    var eventsInInterface = [
+        'PayeeAdded(address,uint256)',
+        'PaymentReleased(address,uint256)',
+        'ERC20PaymentReleased(address,address,uint256)',
+        'PaymentReceived(address,uint256)'
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}

--- a/interface-detector/src/inspectors.ts
+++ b/interface-detector/src/inspectors.ts
@@ -608,3 +608,44 @@ export function isItVotes(events: any[], functions: any[]) {
         eventmatches: null
     }
 }
+
+/****************** FINANCE *******************************/
+
+export function isItVestingWallet(events: any[], functions: any[]) {
+
+    var functionsInInterface: any[] = [
+        'beneficiary()',
+        'start()',
+        'duration()',
+        'released()',
+        'released(address)',
+        'releasable()',
+        'releasable(address)',
+        'release()',
+        'release(address)',
+        'vestedAmount(uint64)',
+        'vestedAmount(address,uint64)'
+    ];
+
+    var eventsInInterface = [
+        'EtherReleased(uint256)',
+        'ERC20Released(address,uint256)',
+    ]
+
+    var {isItInterface, functionMatchesResults, eventMatchesResults} = match(
+        events, 
+        functions, 
+        functionsInInterface, 
+        eventsInInterface
+    )
+
+    if(isItInterface) return {
+        result: true, 
+        functionmatches: functionMatchesResults, 
+        eventmatches: eventMatchesResults
+    }; else return {
+        result: false, 
+        functionmatches: null, 
+        eventmatches: null
+    }
+}


### PR DESCRIPTION
I implemented the following interfaces:

1. From [contracts/token:](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/token)

- ERC1155.
- ERC777.
- ERC721 It has already been implemented but I have modified it by removing the **supportInterface(bytes4)** function because it is from the ERC165 interface.

2. From [contracts/security:](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/security)

- Pausable.
- PullPayment.

3. From [contracts/governance:](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/governance)

- Governor.
- TimelockController.
- Votes.

4. From [contracts/finance:](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/finance)

- VestingWallet.
- PaymentSplitter.

5. From [contracts/utils/introspection:](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/utils/introspection)

- ERC165.